### PR TITLE
fix: ensure dependencies on google_service_account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,5 +37,5 @@ resource "google_project_iam_binding" "compute_manager_binding" {
 
   project = each.key
   role    = "projects/${each.key}/roles/castai.gkeAccess.${substr(sha1(each.key), 0, 8)}.tf"
-  members = compact(["serviceAccount:${local.service_account_email}", var.setup_cloud_proxy_workload_identity ? local.workload_identity_sa : null])
+  members = compact([local.service_account_member, var.setup_cloud_proxy_workload_identity ? local.workload_identity_sa : null])
 }

--- a/output.tf
+++ b/output.tf
@@ -61,7 +61,8 @@ output "default_compute_manager_permissions" {
     "compute.targetPools.get",
     "compute.targetPools.addInstance",
     "compute.targetPools.removeInstance",
-    "compute.instances.use"]
+    "compute.instances.use",
+  ]
 }
 
 output "default_castai_role_permissions" {
@@ -106,5 +107,6 @@ output "default_castai_role_permissions" {
     "compute.targetPools.get",
     "compute.targetPools.addInstance",
     "compute.targetPools.removeInstance",
-    "compute.instances.use"]
+    "compute.instances.use",
+  ]
 }

--- a/service_account.tf
+++ b/service_account.tf
@@ -1,16 +1,17 @@
 moved {
   from = google_service_account.castai_service_account
-  to = google_service_account.castai_service_account[0]
+  to   = google_service_account.castai_service_account[0]
 }
 
 moved {
   from = google_service_account_key.castai_key
-  to = google_service_account_key.castai_key[0]
+  to   = google_service_account_key.castai_key[0]
 }
 
 locals {
-  service_account_id    = "castai-gke-tf-${substr(sha1(var.gke_cluster_name), 0, 8)}"
-  service_account_email = "${local.service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  service_account_id     = "castai-gke-tf-${substr(sha1(var.gke_cluster_name), 0, 8)}"
+  service_account_email  = "${local.service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  service_account_member = var.create_service_account ? google_service_account.castai_service_account[0].member : "serviceAccount:${local.service_account_email}"
 }
 
 resource "google_service_account" "castai_service_account" {
@@ -35,7 +36,7 @@ resource "google_project_iam_member" "project" {
 
   project = var.project_id
   role    = each.key
-  member  = "serviceAccount:${local.service_account_email}"
+  member  = google_service_account.castai_service_account[0].member
 }
 
 resource "google_project_iam_member" "scoped_project" {
@@ -46,7 +47,7 @@ resource "google_project_iam_member" "scoped_project" {
   )
   project = var.project_id
   role    = each.key
-  member  = "serviceAccount:${local.service_account_email}"
+  member  = google_service_account.castai_service_account[0].member
 }
 
 resource "google_project_iam_member" "scoped_service_account_user" {
@@ -54,7 +55,7 @@ resource "google_project_iam_member" "scoped_service_account_user" {
   project = var.project_id
 
   role   = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${local.service_account_email}"
+  member = google_service_account.castai_service_account[0].member
 
   condition {
     title       = "iam_condition"


### PR DESCRIPTION
A set of resources implicitly depended on `google_service_account.castai_service_account` through computing its email "manually" instead of getting it from the resource itself. This meant that Terraform could start creating these before creating the service account.

This led to errors like the following, when the service account wasn't ready yet but Terraform already tried to reference it from other resources:

```
│ Error: Request `Create IAM Members projects/engineering-test-353509/roles/castai.gkeAccess.f8ddae05.tf serviceAccount:castai-gke-tf-f8ddae05@engineering-test-353509.iam.gserviceaccount.com for project "engineering-test-353509"` returned error: Batch request and retried single request "Create IAM Members projects/engineering-test-353509/roles/castai.gkeAccess.f8ddae05.tf serviceAccount:[castai-gke-tf-f8ddae05@engineering-test-353509.iam.gserviceaccount.com](mailto:castai-gke-tf-f8ddae05@engineering-test-353509.iam.gserviceaccount.com) for project \"engineering-test-353509\"" both failed. Final error: Error applying IAM policy for project "engineering-test-353509": Error setting IAM policy for project "engineering-test-353509": googleapi: Error 400: Service account [castai-gke-tf-f8ddae05@engineering-test-353509.iam.gserviceaccount.com](mailto:castai-gke-tf-f8ddae05@engineering-test-353509.iam.gserviceaccount.com) does not exist., badRequest
│
│   with module.castai-gke-iam.google_project_iam_member.project["projects/engineering-test-353509/roles/castai.gkeAccess.f8ddae05.tf"],
│   on .terraform/modules/castai-gke-iam/service_account.tf line 29, in resource "google_project_iam_member" "project":
│   29: resource "google_project_iam_member" "project" {
```

With this PR, I'm making these dependencies explicit by using the `.member` attribute of the service account. This way these resources will only be created after the service account (and will be deleted before it).

## Proof of Work

I've successfully created and onboarded a GKE cluster with this change in place. Since these were intermittent issues, it doesn't 100% prove that they are resolved, but it proves that this didn't break anything.

<img width="2822" height="534" alt="kép" src="https://github.com/user-attachments/assets/512162b2-2494-4f56-843b-cd3bf1e99c6b" />
